### PR TITLE
修复侧边栏上部图标无法隐藏

### DIFF
--- a/src/pages/mainMessage.js
+++ b/src/pages/mainMessage.js
@@ -170,8 +170,8 @@ function chatMessage() {
     updateSiderbarNavFuncList(navStore);
   }
 
-  // 特殊的三个图标
-  const arr = ["消息", "联系人", "更多"];
+  // 特殊的图标
+  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多"];
   for (let i = 0; i < arr.length; i++) {
     const areaLabel = arr[i];
     const findLabel = options.sidebar.top.find((el) => el.name === areaLabel);

--- a/src/render_modules/updateSiderbarNavFuncList.js
+++ b/src/render_modules/updateSiderbarNavFuncList.js
@@ -13,11 +13,14 @@ export function updateSiderbarNavFuncList(navStore) {
     id: tabIcon.id,
     disabled: tabIcon.status === 1 ? false : true,
   }));
-  // 插入特殊的三个图标数据
+  // 插入特殊图标数据
+  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多"];
   top.unshift(
-    { name: "消息", disabled: options?.sidebar?.top?.find((el) => el.name === "消息")?.disabled ?? false, id: -1 },
-    { name: "联系人", disabled: options?.sidebar?.top?.find((el) => el.name === "联系人")?.disabled ?? false, id: -1 },
-    { name: "更多", disabled: options?.sidebar?.top?.find((el) => el.name === "更多")?.disabled ?? false, id: -1 },
+    ...arr.map((name) => ({
+      name,
+      disabled: options?.sidebar?.top?.find((el) => el.name === name)?.disabled ?? false,
+      id: -1,
+    })),
   );
   // 获取侧边栏底部的功能入口
   let bottom = Array.from(document.querySelectorAll(".func-menu.sidebar__menu .func-menu__item"))


### PR DESCRIPTION
Related: #346

---

修复 "QQ游戏" 等侧边栏上部图标无法被轻量工具箱隐藏的问题。

<img width="44" alt="Snipaste_2024-11-05_23-48-58" src="https://github.com/user-attachments/assets/be18d463-a253-4cfa-b5ef-a2150d8cfee6">
<img width="424" alt="Snipaste_2024-11-05_23-44-29" src="https://github.com/user-attachments/assets/1e0e6e5e-cd0b-414c-8892-2bcf25c43040">

<br>此外，QQ 本身允许将这些图标在 更多-管理 中直接关闭。

<img width="336" alt="Snipaste_2024-11-05_23-46-41" src="https://github.com/user-attachments/assets/0b682f13-8101-409e-83ba-0917765d4c14">

---

QQNT: 9.9.16-29271
LiteLoader: 1.2.3
轻量工具箱: 2.33.8