### PR TITLE
修复更多侧边栏按钮无法隐藏

### DIFF
--- a/src/pages/mainMessage.js
+++ b/src/pages/mainMessage.js
@@ -171,7 +171,7 @@ function chatMessage() {
   }
 
   // 特殊的图标
-  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多"];
+  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多", "空间", "频道", "游戏"];
   for (let i = 0; i < arr.length; i++) {
     const areaLabel = arr[i];
     const findLabel = options.sidebar.top.find((el) => el.name === areaLabel);

--- a/src/render_modules/updateSiderbarNavFuncList.js
+++ b/src/render_modules/updateSiderbarNavFuncList.js
@@ -14,7 +14,7 @@ export function updateSiderbarNavFuncList(navStore) {
     disabled: tabIcon.status === 1 ? false : true,
   }));
   // 插入特殊图标数据
-  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多"];
+  const arr = ["消息", "联系人", "短视频", "腾讯文档", "QQ游戏", "自选股", "腾讯网", "微云", "QQ音乐", "QQ钱包", "更多", "空间", "频道", "游戏"];
   top.unshift(
     ...arr.map((name) => ({
       name,


### PR DESCRIPTION
Related: #356

添加 "空间", "频道", "游戏" 三个按钮的检测。
（#356 中提到的 "邮箱"、"文件"、"收藏" 仍暂未修复）

---

QQNT: 9.9.16-29804
LiteLoader: 1.2.3
轻量工具箱: 2.33.8