### PR TITLE
fix: 修复切换页面时MutationObserver未断开导致QQ卡顿

### DIFF
--- a/src/renderer/modules/handleMessages/index.ts
+++ b/src/renderer/modules/handleMessages/index.ts
@@ -137,6 +137,11 @@ function enhanceMessage(component: any) {
 async function observerElement() {
   const target = await waitForElement(".chat-msg-area__vlist");
   const observer = new MutationObserver((mutationsList) => {
+    // 元素已不在DOM中时断开观察，避免切换页面时产生无用回调
+    if (!target.isConnected) {
+      observer.disconnect();
+      return;
+    }
     for (let mutation of mutationsList) {
       if (mutation.type === "childList") {
         const target = mutation.target as HTMLElement;

--- a/src/renderer/modules/handleMessages/index.ts
+++ b/src/renderer/modules/handleMessages/index.ts
@@ -135,10 +135,10 @@ function enhanceMessage(component: any) {
 }
 
 async function observerElement() {
-  const target = await waitForElement(".chat-msg-area__vlist");
+  const observedTarget = await waitForElement(".chat-msg-area__vlist");
   const observer = new MutationObserver((mutationsList) => {
     // 元素已不在DOM中时断开观察，避免切换页面时产生无用回调
-    if (!target.isConnected) {
+    if (!observedTarget.isConnected) {
       observer.disconnect();
       return;
     }


### PR DESCRIPTION
## 问题描述

在 QQ 6.9.96-49738 (macOS) 上，打开聊天详情页后切换到联系人页面，整个 QQ 主页面会卡住。

## 原因分析

`observerElement()` 函数创建了 `MutationObserver` 监听 `.chat-msg-area__vlist` 的子树变化，但**从未断开连接**。

当用户切换到联系人页面时，聊天区域的 DOM 被销毁重建，触发大量无用的 mutation 回调，导致主线程阻塞。

## 修复方式

在 observer 回调开头检查 `target.isConnected`，当目标元素不在 DOM 中时自动断开观察：

```typescript
const observer = new MutationObserver((mutationsList) => {
    // 元素已不在DOM中时断开观察，避免切换页面时产生无用回调
    if (!target.isConnected) {
      observer.disconnect();
      return;
    }
    // ...原有逻辑
});
```

## 复现步骤

1. 安装 lite-tools dev/v5 分支
2. 打开任意聊天详情页
3. 切换到联系人页面
4. QQ 主页面卡住

## 环境

- QQ: 6.9.96-49738 (macOS)
- lite-tools: dev/v5 (v4.0.0-alpha.dev)
- LiteLoaderQQNT: 1.4.1